### PR TITLE
Allowing both network and filesystem listening for Redis

### DIFF
--- a/docker/rediscache/redis.conf
+++ b/docker/rediscache/redis.conf
@@ -89,7 +89,7 @@ protected-mode yes
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 0
+port 6379
 
 # TCP listen() backlog.
 #

--- a/docker/redisfullpage/redis.conf
+++ b/docker/redisfullpage/redis.conf
@@ -89,7 +89,7 @@ protected-mode yes
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 0
+port 6379
 
 # TCP listen() backlog.
 #

--- a/docker/redissession/redis.conf
+++ b/docker/redissession/redis.conf
@@ -89,7 +89,7 @@ protected-mode yes
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 0
+port 6379
 
 # TCP listen() backlog.
 #


### PR DESCRIPTION
I had someone provide feedback today that they needed to access Redis through network sockets rather than the filesystem socket.

The stack didn't allow it and it should, it's not supposed to be opinionated.

The difference in performance is significant though, so if you can, use the filesystem sockets in /tmp.
![image](https://user-images.githubusercontent.com/25080134/234063282-07d31880-c6fc-49e8-b9e7-825fbd2281a6.png)
